### PR TITLE
Corrected HTML code

### DIFF
--- a/views.md
+++ b/views.md
@@ -13,7 +13,11 @@ A simple view looks like this:
 
 	<!-- View stored in resources/views/greeting.php -->
 
+	<!doctype html>
 	<html>
+		<head>
+			<title>Welcome!</title>
+		</head>
 		<body>
 			<h1>Hello, <?php echo $name; ?></h1>
 		</body>


### PR DESCRIPTION
I think it's not a good idea to promote invalid HTML code in official documentations.

If you don't think it's great because it's long, you can do:

``` html
<!doctype html>
<title>Welcome!</title>

<h1>Hello, <?php echo $name; ?></h1>
```

But leaving out the doctype + title elements is wrong, as those are the only 2 required elements in HTML.
