### PR TITLE
Add missed leading slash

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -68,7 +68,7 @@ The `getContent` method will return the evaluated string contents of the respons
 
 To call a HTTPS route, you may use the `callSecure` method:
 
-	$response = $this->callSecure('GET', 'foo/bar');
+	$response = $this->callSecure('GET', '/foo/bar');
 
 <a name="mocking-facades"></a>
 ## Mocking Facades


### PR DESCRIPTION
I swear I'm not just trying to keep you busy! Missed a leading slash in the doc. I'll re-read the whole thing next time. :see_no_evil: 
