### PR TITLE
change the core version of the first Lumen

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 - [5.0.4](#5.0.4)
-- [5.0 (Based On Laravel 5.x)](#5.0)
+- [5.0 (Based On Laravel 5.0.x)](#5.0)
 
 <a name="5.0.4"></a>
 ## Lumen 5.0.4


### PR DESCRIPTION
The first Lumen based on Laravel 5.0 (5.0.x)

Laravel 5.x.x quite different from Laravel 5.0.x

source:
http://laravel.com/docs/master/upgrade#upgrade-5.1.0
