### PR TITLE
csrf_field() helper doesn't exist in Lumen

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -91,7 +91,7 @@ Now, let's write a test that clicks the link and asserts the user lands on the c
 Lumen also provides several methods for testing forms. The `type`, `select`, `check`, `attach`, and `press` methods allow you to interact with all of your form's inputs. For example, let's imagine this form exists on the application's registration page:
 
 	<form action="/register" method="POST">
-		{!! csrf_field() !!}
+		<input type="hidden" value="{{ csrf_token() }}" name="_token">
 
 		<div>
 			Name: <input type="text" name="name">


### PR DESCRIPTION
The function `csrf_field()` doesn't exist as an helper in Lumen, we need to use the longer version `<input type="hidden" value="{{ csrf_token() }}" name="_token">`
