### PR TITLE
Add illuminate/redis dependency.

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -30,7 +30,7 @@ Using the Memcached cache requires the [Memcached PECL package](http://pecl.php.
 
 #### Redis
 
-Before using a Redis cache with Lumen, you will need to install the `predis/predis` package (~1.0) via Composer.
+Before using a Redis cache with Lumen, you will need to install the `predis/predis` package (~1.0) and `illuminate/redis` package (~5.1) via Composer.
 
 <a name="cache-usage"></a>
 ## Cache Usage

--- a/session.md
+++ b/session.md
@@ -43,7 +43,7 @@ When using the `database` session driver, you will need to setup a table to cont
 
 #### Redis
 
-Before using Redis sessions with Lumen, you will need to install the `predis/predis` package (~1.0) via Composer.
+Before using Redis sessions with Lumen, you will need to install the `predis/predis` package (~1.0) and `illuminate/redis` package (~5.1) via Composer.
 
 ### Other Session Considerations
 


### PR DESCRIPTION
To use redis for caching or sessions the illuminate/redis dependency is also
required. The docs had this but it was lost in later refactoring.
