### PR TITLE
Fixing route group namespaces

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -132,17 +132,11 @@ To assign middleware to all routes within a group, you may use the `middleware` 
 
 Another common use-case for route groups is assigning the same PHP namespace to a group of controllers. You may use the `namespace` parameter in your group attribute array to specify the namespace for all controllers within the group:
 
-	$app->group(['namespace' => 'Admin'], function()
-	{
+	$app->group(['namespace' => 'App\Http\Controllers\Admin'], function ($app) {
+
 		// Controllers Within The "App\Http\Controllers\Admin" Namespace
 
-		Route::group(['namespace' => 'User'], function()
-		{
-			// Controllers Within The "App\Http\Controllers\Admin\User" Namespace
-		});
 	});
-
-Remember, by default, the `RouteServiceProvider` includes your `routes.php` file within a namespace group, allowing you to register controller routes without specifying the full `App\Http\Controllers` namespace prefix. So, we only need to specify the portion of the namespace that comes after the base `App\Http\Controllers` namespace root.
 
 <a name="route-group-prefixes"></a>
 ### Route Prefixes


### PR DESCRIPTION
It's missing the $app variable.

The example also used the Route facade.

I believe route groups also require the full namespace since it'll override the default one.

RouteServiceProvider doesn't exist in the Lumen framework.
