### PR TITLE
Remove the InteractsWithQueue trait from job Class

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -66,7 +66,7 @@ By default, all of the queueable jobs for your application are stored in the `ap
 
 	class SendReminderEmail extends Job implements SelfHandling, ShouldQueue
 	{
-	    use InteractsWithQueue, SerializesModels;
+	    use SerializesModels;
 
 	    protected $user;
 


### PR DESCRIPTION
I recommend removing the InteractsWithQueue trait from the job class as it interferes with the trait already in use by App\Jobs\Job.  Including it results in this error:

App\Jobs\Job and Illuminate\Queue\InteractsWithQueue define the same property ($job) in the composition of App\Jobs\NewJob. This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed
