### PR TITLE
Added fully qualified class name to named routes

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -86,7 +86,7 @@ Named routes allow you to conveniently generate URLs or redirects for a specific
 You may also specify route names for controller actions:
 
 	$app->get('user/profile', [
-		'as' => 'profile', 'uses' => 'UserController@showProfile'
+		'as' => 'profile', 'uses' => 'App\Http\Controllers\UserController@showProfile'
 	]);
 
 #### Generating URLs To Named Routes


### PR DESCRIPTION
Route will return a `Class ExampleController not found` error if the route is not fully qualified.
