### PR TITLE
Added fully qualified class name to named routes

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -67,7 +67,7 @@ Named routes allow the convenient generation of URLs or redirects for specific r
 You may also specify route names for controller actions:
 
     $app->get('profile', [
-        'as' => 'profile', 'uses' => 'UserController@showProfile'
+        'as' => 'profile', 'uses' => 'App\Http\Controllers\UserController@showProfile'
     ]);
 
 #### Generating URLs To Named Routes


### PR DESCRIPTION
You need to supply a fully qualified class name to a named route or you will get `Class ExampleController Not Found`
