### PR TITLE
Fix missing use on closure when using groups within groups

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -119,7 +119,7 @@ Another common use-case for route groups is assigning the same PHP namespace to 
     {
         // Controllers Within The "App\Http\Controllers\Admin" Namespace
 
-        $app->group(['namespace' => 'User'], function() {
+        $app->group(['namespace' => 'User'], function() use ($app) {
             // Controllers Within The "App\Http\Controllers\Admin\User" Namespace
         });
     });


### PR DESCRIPTION
Just to add a little clarification on how groups within groups work. Not everyone is familiar with the "use" options on closures as they're still a relatively new thing in PHP.
