### PR TITLE
Added extra documentation for Redis

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -9,3 +9,5 @@ Laravel provides a unified API for various caching systems. The cache configurat
 The Lumen cache drivers utilize the exact same code as the full Laravel cache drivers. Beyond configuration, there are no differences between using the cache in Lumen and using the cache in Laravel; therefore, please consult the [full Laravel documentation](https://laravel.com/docs/cache) for usage examples.
 
 > **Note:** Before using the `Cache` facade, be sure you have uncommented the `$app->withFacades()` method call in your `bootstrap/app.php` file.
+
+> **Note 2:** Before using a Redis cache with Lumen, you will need to install the predis/predis (~1.0) and illuminate/redis (5.2.*) packages via Composer. Also register the `Illuminate\Redis\RedisServiceProvider` in your `bootstrap/app.php`.


### PR DESCRIPTION
The predis/predis requirement is listed on the Laravel cache documention, but since 5.2 removed the automatic registration of Illuminate\Redis\RedisServiceProvider I thought it might be a good idea to add this clarification to the docs.
