### PR TITLE
Fix wrong documentation for Lumen/Routing

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -115,16 +115,14 @@ To assign middleware to all routes within a group, you may use the `middleware` 
 
 Another common use-case for route groups is assigning the same PHP namespace to a group of controllers. You may use the `namespace` parameter in your group attribute array to specify the namespace for all controllers within the group:
 
-    $app->group(['namespace' => 'Admin'], function() use ($app)
+    $app->group(['namespace' => 'App\Http\Controllers\Admin'], function() use ($app)
     {
         // Controllers Within The "App\Http\Controllers\Admin" Namespace
 
-        $app->group(['namespace' => 'User'], function() use ($app) {
+        $app->group(['namespace' => 'App\Http\Controllers\Admin\User'], function() use ($app) {
             // Controllers Within The "App\Http\Controllers\Admin\User" Namespace
         });
     });
-
-Remember, by default, the `bootstrap/app.php` file includes your `routes.php` file within a namespace group, allowing you to register controller routes without specifying the full `App\Http\Controllers` namespace prefix. So, we only need to specify the portion of the namespace that comes after the base `App\Http\Controllers` namespace.
 
 <a name="route-group-prefixes"></a>
 ### Route Prefixes


### PR DESCRIPTION
This commit fixes the documentation regarding routing namespaces. The docs state that it automatically prefixes with App\Http\Controllers, which it does not, as stated in issue 197 in laravel/lumen: https://github.com/laravel/lumen-framework/issues/197
