### PR TITLE
Update 5.2 upgrade instructions

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -11,7 +11,7 @@ Upgrading your Lumen application to the full Laravel framework mainly involves c
 
 ### Updating Dependencies
 
-Update your `composer.json` file to point to `laravel/lumen-framework 5.2.*`.
+Update your `composer.json` file to point to `laravel/lumen-framework 5.2.*` and `vlucas/phpdotenv ~2.2`.
 
 ### Bootstrap
 


### PR DESCRIPTION
The upgrade instructions for 5.2 missed out changing the phpdotenv version from ~1.0 to ~2.2
