### PR TITLE
Use the proper namespace to Crypt facade.

### DIFF
--- a/encryption.md
+++ b/encryption.md
@@ -21,7 +21,7 @@ For example, we may use the `encrypt` method to encrypt a secret and store it on
 
 	namespace App\Http\Controllers;
 
-	use Crypt;
+	use Illuminate\Support\Facades\Crypt;
 	use App\User;
 	use Illuminate\Http\Request;
 


### PR DESCRIPTION
use Crypt; does not work, as of issue #307 (https://github.com/laravel/lumen-framework/issues/307) I learned that Crypt is only an alias, but that does not work out of the box so the full namespace to Crypt facade makes sense here?
