### PR TITLE
Add an example JSON response with a status code and header.

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -70,6 +70,10 @@ The `json` method will automatically set the `Content-Type` header to `applicati
 
     return response()->json(['name' => 'Abigail', 'state' => 'CA']);
 
+You can optionally provide a status code and an array of additional headers:
+
+    return response()->json(['error' => 'Unauthorized'], 401, ['X-Header-One' => 'Header Value']);
+
 If you would like to create a JSONP response, you may use the `json` method in addition to `setCallback`:
 
     return response()


### PR DESCRIPTION
The docs talk about customizing status codes but don't show any examples of it in action. Added an example JSON response with a status code and a custom header for clarity. I didn't include a non-JSON response with status code/header because the linked Laravel docs have one, but I can add it in if you think it'd clarify things a bit more.
