### PR TITLE
Change configuration example

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -15,11 +15,11 @@ All of the configuration options for the Lumen framework are stored in the `.env
 
 You may easily access your configuration values using the global `config` helper function from anywhere in your application. The configuration values may be accessed using "dot" syntax, which includes the name of the file and option you wish to access. A default value may also be specified and will be returned if the configuration option does not exist:
 
-    $value = config('app.timezone');
+    $value = config('app.locale');
 
 To set configuration values at runtime, pass an array to the `config` helper:
 
-    config(['app.timezone' => 'America/Chicago']);
+    config(['app.locale' => 'en']);
 
 <a name="environment-configuration"></a>
 ## Environment Configuration


### PR DESCRIPTION
The only way to set the _timezone_ in Lumen is with the environment variable `APP_TIMEZONE`
