### PR TITLE
Updates to use the Router instance

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -24,7 +24,7 @@ Just like in the full Laravel framework, you may use the `Auth::user()` method t
 
 	use Illuminate\Http\Request;
 
-	$app->get('/post/{id}', ['middleware' => 'auth', function (Request $request, $id) {
+	$router->get('/post/{id}', ['middleware' => 'auth', function (Request $request, $id) {
 		$user = Auth::user();
 
 		$user = $request->user();

--- a/controllers.md
+++ b/controllers.md
@@ -37,7 +37,7 @@ Here is an example of a basic controller class. All Lumen controllers should ext
 
 We can route to the controller action like so:
 
-    $app->get('user/{id}', 'UserController@show');
+    $router->get('user/{id}', 'UserController@show');
 
 Now, when a request matches the specified route URI, the `show` method on the `UserController` class will be executed. Of course, the route parameters will also be passed to the method.
 
@@ -47,13 +47,13 @@ It is very important to note that we did not need to specify the full controller
 
 If you choose to nest or organize your controllers using PHP namespaces deeper into the `App\Http\Controllers` directory, simply use the specific class name relative to the `App\Http\Controllers` root namespace. So, if your full controller class is `App\Http\Controllers\Photos\AdminController`, you would register a route like so:
 
-    $app->get('foo', 'Photos\AdminController@method');
+    $router->get('foo', 'Photos\AdminController@method');
 
 #### Naming Controller Routes
 
 Like Closure routes, you may specify names on controller routes:
 
-    $app->get('foo', ['uses' => 'FooController@method', 'as' => 'name']);
+    $router->get('foo', ['uses' => 'FooController@method', 'as' => 'name']);
 
 You may also use the `route` helper to generate a URL to a named controller route:
 
@@ -64,7 +64,7 @@ You may also use the `route` helper to generate a URL to a named controller rout
 
 [Middleware](/docs/{{version}}/middleware) may be assigned to the controller's routes like so:
 
-    $app->get('profile', [
+    $router->get('profile', [
         'middleware' => 'auth',
         'uses' => 'UserController@showProfile'
     ]);
@@ -154,7 +154,7 @@ In addition to constructor injection, you may also type-hint dependencies on you
 
 If your controller method is also expecting input from a route parameter, simply list your route arguments after your other dependencies. For example, if your route is defined like so:
 
-    $app->put('user/{id}', 'UserController@update');
+    $router->put('user/{id}', 'UserController@update');
 
 You may still type-hint the `Illuminate\Http\Request` and access your route parameter `id` by defining your controller method like the following:
 

--- a/middleware.md
+++ b/middleware.md
@@ -115,13 +115,13 @@ If you would like to assign middleware to specific routes, you should first assi
 
 Once the middleware has been defined in the HTTP kernel, you may use the `middleware` key in the route options array:
 
-    $app->get('admin/profile', ['middleware' => 'auth', function () {
+    $router->get('admin/profile', ['middleware' => 'auth', function () {
         //
     }]);
 
 Use an array to assign multiple middleware to the route:
 
-    $app->get('/', ['middleware' => ['first', 'second'], function () {
+    $router->get('/', ['middleware' => ['first', 'second'], function () {
         //
     }]);
 
@@ -161,7 +161,7 @@ Additional middleware parameters will be passed to the middleware after the `$ne
 
 Middleware parameters may be specified when defining the route by separating the middleware name and parameters with a `:`. Multiple parameters should be delimited by commas:
 
-    $app->put('post/{id}', ['middleware' => 'role:editor', function ($id) {
+    $router->put('post/{id}', ['middleware' => 'role:editor', function ($id) {
         //
     }]);
 

--- a/requests.md
+++ b/requests.md
@@ -35,7 +35,7 @@ To obtain an instance of the current HTTP request via dependency injection, you 
 
 If your controller method is also expecting input from a route parameter, simply list your route arguments after your other dependencies. For example, if your route is defined like so:
 
-    $app->put('user/{id}', 'UserController@update');
+    $router->put('user/{id}', 'UserController@update');
 
 You may still type-hint the `Illuminate\Http\Request` and access your route parameter `id` by defining your controller method like the following:
 
@@ -108,7 +108,7 @@ Once you have installed these libraries, you may obtain a PSR-7 request by simpl
 
     use Psr\Http\Message\ServerRequestInterface;
 
-    $app->get('/', function (ServerRequestInterface $request) {
+    $router->get('/', function (ServerRequestInterface $request) {
         //
     });
 

--- a/responses.md
+++ b/responses.md
@@ -13,7 +13,7 @@
 
 Of course, all routes and controllers should return some kind of response to be sent back to the user's browser. Lumen provides several different ways to return responses. The most basic response is simply returning a string from a route or controller:
 
-    $app->get('/', function () {
+    $router->get('/', function () {
         return 'Hello World';
     });
 
@@ -25,14 +25,14 @@ However, for most routes and controller actions, you will be returning a full `I
 
     use Illuminate\Http\Response;
 
-    $app->get('home', function () {
+    $router->get('home', function () {
         return (new Response($content, $status))
                       ->header('Content-Type', $value);
     });
 
 For convenience, you may also use the `response` helper:
 
-    $app->get('home', function () {
+    $router->get('home', function () {
         return response($content, $status)
                       ->header('Content-Type', $value);
     });
@@ -96,7 +96,7 @@ The `download` method may be used to generate a response that forces the user's 
 
 Redirect responses are instances of the `Illuminate\Http\RedirectResponse` class, and contain the proper headers needed to redirect the user to another URL. There are several ways to generate a `RedirectResponse` instance. The simplest method is to use the global `redirect` helper method:
 
-    $app->get('dashboard', function () {
+    $router->get('dashboard', function () {
         return redirect('home/dashboard');
     });
 

--- a/routing.md
+++ b/routing.md
@@ -16,11 +16,11 @@
 
 You will define all of the routes for your application in the `routes/web.php` file. The most basic Lumen routes simply accept a URI and a `Closure`:
 
-    $app->get('foo', function () {
+    $router->get('foo', function () {
         return 'Hello World';
     });
 
-    $app->post('foo', function () {
+    $router->post('foo', function () {
         //
     });
 
@@ -28,12 +28,12 @@ You will define all of the routes for your application in the `routes/web.php` f
 
 The router allows you to register routes that respond to any HTTP verb:
 
-    $app->get($uri, $callback);
-    $app->post($uri, $callback);
-    $app->put($uri, $callback);
-    $app->patch($uri, $callback);
-    $app->delete($uri, $callback);
-    $app->options($uri, $callback);
+    $router->get($uri, $callback);
+    $router->post($uri, $callback);
+    $router->put($uri, $callback);
+    $router->patch($uri, $callback);
+    $router->delete($uri, $callback);
+    $router->options($uri, $callback);
 
 <a name="route-parameters"></a>
 ## Route Parameters
@@ -43,13 +43,13 @@ The router allows you to register routes that respond to any HTTP verb:
 
 Of course, sometimes you will need to capture segments of the URI within your route. For example, you may need to capture a user's ID from the URL. You may do so by defining route parameters:
 
-    $app->get('user/{id}', function ($id) {
+    $router->get('user/{id}', function ($id) {
         return 'User '.$id;
     });
 
 You may define as many route parameters as required by your route:
 
-    $app->get('posts/{postId}/comments/{commentId}', function ($postId, $commentId) {
+    $router->get('posts/{postId}/comments/{commentId}', function ($postId, $commentId) {
         //
     });
 
@@ -62,7 +62,7 @@ Route parameters are always encased within "curly" braces. The parameters will b
 
 You may define optional route parameters by enclosing part of the route URI definition in `[...]`. So, for example, `/foo[bar]` will match both `/foo` and `/foobar`. Optional parameters are only supported in a trailing position of the URI. In other words, you may not place an optional parameter in the middle of a route definition:
 
-    $app->get('user[/{name}]', function ($name = null) {
+    $router->get('user[/{name}]', function ($name = null) {
         return $name;
     });
 
@@ -71,7 +71,7 @@ You may define optional route parameters by enclosing part of the route URI defi
 
 You may constrain the format of your route parameters by defining a regular expression in your route definition:
 
-    $app->get('user/{name:[A-Za-z]+}', function ($name) {
+    $router->get('user/{name:[A-Za-z]+}', function ($name) {
         //
     });
 
@@ -80,13 +80,13 @@ You may constrain the format of your route parameters by defining a regular expr
 
 Named routes allow the convenient generation of URLs or redirects for specific routes. You may specify a name for a route using the `as` array key when defining the route:
 
-    $app->get('profile', ['as' => 'profile', function () {
+    $router->get('profile', ['as' => 'profile', function () {
         //
     }]);
 
 You may also specify route names for controller actions:
 
-    $app->get('profile', [
+    $router->get('profile', [
         'as' => 'profile', 'uses' => 'UserController@showProfile'
     ]);
 
@@ -102,7 +102,7 @@ Once you have assigned a name to a given route, you may use the route's name whe
 
 If the named route defines parameters, you may pass the parameters as the second argument to the `route` function. The given parameters will automatically be inserted into the URL in their correct positions:
 
-    $app->get('user/{id}/profile', ['as' => 'profile', function ($id) {
+    $router->get('user/{id}/profile', ['as' => 'profile', function ($id) {
         //
     }]);
 
@@ -111,7 +111,7 @@ If the named route defines parameters, you may pass the parameters as the second
 <a name="route-groups"></a>
 ## Route Groups
 
-Route groups allow you to share route attributes, such as middleware or namespaces, across a large number of routes without needing to define those attributes on each individual route. Shared attributes are specified in an array format as the first parameter to the `$app->group` method.
+Route groups allow you to share route attributes, such as middleware or namespaces, across a large number of routes without needing to define those attributes on each individual route. Shared attributes are specified in an array format as the first parameter to the `$router->group` method.
 
 To learn more about route groups, we'll walk through several common use-cases for the feature.
 
@@ -120,12 +120,12 @@ To learn more about route groups, we'll walk through several common use-cases fo
 
 To assign middleware to all routes within a group, you may use the `middleware` key in the group attribute array. Middleware will be executed in the order you define this array:
 
-    $app->group(['middleware' => 'auth'], function () use ($app) {
-        $app->get('/', function ()    {
+    $router->group(['middleware' => 'auth'], function () use ($router) {
+        $router->get('/', function ()    {
             // Uses Auth Middleware
         });
 
-        $app->get('user/profile', function () {
+        $router->get('user/profile', function () {
             // Uses Auth Middleware
         });
     });
@@ -135,11 +135,11 @@ To assign middleware to all routes within a group, you may use the `middleware` 
 
 Another common use-case for route groups is assigning the same PHP namespace to a group of controllers. You may use the `namespace` parameter in your group attribute array to specify the namespace for all controllers within the group:
 
-    $app->group(['namespace' => 'Admin'], function() use ($app)
+    $router->group(['namespace' => 'Admin'], function() use ($router)
     {
         // Using The "App\Http\Controllers\Admin" Namespace...
 
-        $app->group(['namespace' => 'User'], function() use ($app) {
+        $router->group(['namespace' => 'User'], function() use ($router) {
             // Using The "App\Http\Controllers\Admin\User" Namespace...
         });
     });
@@ -149,16 +149,16 @@ Another common use-case for route groups is assigning the same PHP namespace to 
 
 The `prefix` group attribute may be used to prefix each route in the group with a given URI. For example, you may want to prefix all route URIs within the group with `admin`:
 
-    $app->group(['prefix' => 'admin'], function () use ($app) {
-        $app->get('users', function ()    {
+    $router->group(['prefix' => 'admin'], function () use ($router) {
+        $router->get('users', function ()    {
             // Matches The "/admin/users" URL
         });
     });
 
 You may also use the `prefix` parameter to specify common parameters for your grouped routes:
 
-    $app->group(['prefix' => 'accounts/{accountId}'], function () use ($app) {
-        $app->get('detail', function ($accountId)    {
+    $router->group(['prefix' => 'accounts/{accountId}'], function () use ($router) {
+        $router->get('detail', function ($accountId)    {
             // Matches The "/accounts/{accountId}/detail" URL
         });
     });

--- a/upgrade.md
+++ b/upgrade.md
@@ -24,6 +24,14 @@ In Laravel 5.5, the service container implements the PSR-11 interface, causing c
         require __DIR__.'/../routes/web.php';
     });
 
+### Updating The Routes File
+
+The Routes file needs to be updated to reflect the Bootstrap file update to use the Router instance, So replace any use of `$app` parameter with the `$router` parameter in the routes definitions in `routes/web.php`:
+
+    $router->get('foo', function () {
+        return 'Hello World';
+    });
+
 <a name="upgrade-5.4.0"></a>
 ## Upgrading To 5.4.0 From 5.3
 

--- a/validation.md
+++ b/validation.md
@@ -21,7 +21,7 @@ Unlike Laravel, Lumen provides access to the `validate` method from within Route
 
 	use Illuminate\Http\Request;
 
-	$app->post('/user', function (Request $request) {
+	$router->post('/user', function (Request $request) {
 		$this->validate($request, [
 			'name' => 'required',
 			'email' => 'required|email|unique:users'


### PR DESCRIPTION
- replaced the `$app` param with `$router` in the docs for routes definitions.
- added a note in the `5.5` upgrade guide for replacing `$app` with `$router` param in the routes file.

_Also the code in the HomePage needs to be updated to use the router param._