### PR TITLE
Reference correct version of illuminate/redis

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -12,6 +12,6 @@ The Lumen cache drivers utilize the exact same code as the full Laravel cache dr
 
 ### Redis Support
 
-Before using a Redis cache with Lumen, you will need to install the `predis/predis (~1.0)` and `illuminate/redis (5.4.*)` packages via Composer. Then, you should register the `Illuminate\Redis\RedisServiceProvider` in your `bootstrap/app.php` file.
+Before using a Redis cache with Lumen, you will need to install `illuminate/redis (5.5.*)` package via Composer. Then, you should register the `Illuminate\Redis\RedisServiceProvider` in your `bootstrap/app.php` file.
 
 If you have not called `$app->withEloquent()` in your `bootstrap/app.php` file, then you should call `$app->configure('database');` in the `bootstrap/app.php` file to ensure the Redis database configuration is properly loaded.

--- a/cache.md
+++ b/cache.md
@@ -12,6 +12,6 @@ The Lumen cache drivers utilize the exact same code as the full Laravel cache dr
 
 ### Redis Support
 
-Before using a Redis cache with Lumen, you will need to install `illuminate/redis (5.5.*)` package via Composer. Then, you should register the `Illuminate\Redis\RedisServiceProvider` in your `bootstrap/app.php` file.
+Before using a Redis cache with Lumen, you will need to install the `illuminate/redis (5.5.*)` package via Composer. Then, you should register the `Illuminate\Redis\RedisServiceProvider` in your `bootstrap/app.php` file.
 
 If you have not called `$app->withEloquent()` in your `bootstrap/app.php` file, then you should call `$app->configure('database');` in the `bootstrap/app.php` file to ensure the Redis database configuration is properly loaded.


### PR DESCRIPTION
I also removed the reference to `predis/predis` since it's already a dependency of `illuminate/redis`.