### PR TITLE
Updated routing.md

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -57,6 +57,8 @@ Route parameters are always encased within "curly" braces. The parameters will b
 
 > **Note:** Route parameters cannot contain the `-` character. Use an underscore (`_`) instead.
 
+> **Note:** Route parameters **must** match the corresponding variable names.
+
 <a name="optional-parameters"></a>
 ### Optional Parameters
 


### PR DESCRIPTION
Through some debugging on the *discord* channel we found that Lumen **does** care about what you name your parameters whereas Laravel does not. It would be nice to have a notice in there so it is specified for those coming from Laravel and don't match up their parameter names with variables.

Simple test cases

Url: `test/12/2/6/1983`
```
$router->get('/test/{id}/{day}/{month}/{year}', function ($id,$day,$month,$year) {
    echo "$id - $day - $month - $year";
});
```
Return: `12 - 2 - 6 - 1983`

versus

Url: `test/12/2/6/1983`
```
$router->get('/test/{anotherId}/{day}/{month}/{year}', function ($id,$day,$month,$year) {
    echo "$id - $day - $month - $year";
});
```
Return: `2 - 6 - 1983 - 12`