### PR TITLE
reserved field in jobs table causes an error

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -25,7 +25,6 @@ In order to use the `database` queue driver, you will need database tables to ho
         $table->string('queue');
         $table->longText('payload');
         $table->tinyInteger('attempts')->unsigned();
-        $table->tinyInteger('reserved')->unsigned();
         $table->unsignedInteger('reserved_at')->nullable();
         $table->unsignedInteger('available_at');
         $table->unsignedInteger('created_at');


### PR DESCRIPTION
The `reserved` field in the `jobs` table causes a `NOT NULL constraint`error. I compared these migrations with the ones `php artisan queue:table` creates in Laravel and there is no `reserved` field as well.