### PR TITLE
Index error: Key column 'reserved' doesn't exist in jobs table

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -28,7 +28,7 @@ In order to use the `database` queue driver, you will need database tables to ho
         $table->unsignedInteger('reserved_at')->nullable();
         $table->unsignedInteger('available_at');
         $table->unsignedInteger('created_at');
-        $table->index(['queue', 'reserved', 'reserved_at']);
+        $table->index(['queue', 'reserved_at']);
     });
 
     Schema::create('failed_jobs', function (Blueprint $table) {


### PR DESCRIPTION
In addition to PR #142 from rico/patch-5, also remove index for the 'reserved' field in jobs table.