### PR TITLE
[5.7] Add link to Laravel docs about error handling

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -6,5 +6,6 @@
 ## Introduction
 
 When you start a new Lumen project, error and exception handling is already configured for you. In addition, Lumen is integrated with the [Monolog](https://github.com/Seldaek/monolog) logging library, which provides support for a variety of powerful log handlers.
-
+  
+For more information on errors, please consult the full Laravel [documentation on errors](https://laravel.com/docs/errors).  
 For more information on logging, please consult the full Laravel [documentation on logging](https://laravel.com/docs/logging).

--- a/errors.md
+++ b/errors.md
@@ -6,6 +6,6 @@
 ## Introduction
 
 When you start a new Lumen project, error and exception handling is already configured for you. In addition, Lumen is integrated with the [Monolog](https://github.com/Seldaek/monolog) logging library, which provides support for a variety of powerful log handlers.
-  
+
 For more information on errors, please consult the full Laravel [documentation on errors](https://laravel.com/docs/errors).  
 For more information on logging, please consult the full Laravel [documentation on logging](https://laravel.com/docs/logging).


### PR DESCRIPTION
The docs only give info about loggin at the moment but not error handling (even though the title says so). This adds a link to the Laravel docs about error handling.

Fixes https://github.com/laravel/lumen-framework/issues/727