### PR TITLE
[5.7] Add note about loading config files

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -20,6 +20,10 @@ You may easily access your configuration values using the global `config` helper
 To set configuration values at runtime, pass an array to the `config` helper:
 
     config(['app.locale' => 'en']);
+    
+Before a config file can be used you'll need to load it into the application. This can be done in your `bootstrap/app.php` file.
+
+    $app->configure('app');
 
 <a name="environment-configuration"></a>
 ## Environment Configuration


### PR DESCRIPTION
Config files need to be loaded into the application before they can be used. This note makes that clear.

Might be worth considering to already pre-load the `app.php` config file by default in a future release.

See https://github.com/laravel/lumen-framework/issues/672