### PR TITLE
[5.7] Add mail aliases to install instructions

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -16,6 +16,12 @@ After creating the configuration file, you should register it within your `boots
 
     $app->configure('mail');
 
+And you should register the container aliases:
+
+    $app->alias('mailer', Illuminate\Mail\Mailer::class);
+    $app->alias('mailer', Illuminate\Contracts\Mail\Mailer::class);
+    $app->alias('mailer', Illuminate\Contracts\Mail\MailQueue::class);
+
 The following configuration options should also be available to your Lumen application's `.env` file:
 
     MAIL_DRIVER=smtp


### PR DESCRIPTION
Mail aliases are needed in order for the component to properly function with Lumen and queued mails. See https://github.com/laravel/lumen-framework/issues/859 for more info.