### PR TITLE
[5.8] Re-Add views doc to documentation menu

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -24,3 +24,4 @@
     - [Service Providers](/docs/{{version}}/providers)
     - [Testing](/docs/{{version}}/testing)
     - [Validation](/docs/{{version}}/validation)
+    - [Views](/docs/{{version}}/views)


### PR DESCRIPTION
Views documentation page was recently re-added.
This merge request adds that page to the documentation menu.