### PR TITLE
[5.8] Mention the obscure 'uses' notation for controller actions

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -119,6 +119,10 @@ Once the middleware has been defined in the HTTP kernel, you may use the `middle
         //
     }]);
 
+Or without closure notation, using the `uses` key to specify controller actions as a string:
+
+    $router->get('admin/profile', ['middleware' => 'auth', 'uses' => 'AdminController@showProfile']);
+
 Use an array to assign multiple middleware to the route:
 
     $router->get('/', ['middleware' => ['first', 'second'], function () {


### PR DESCRIPTION
All the examples in the Middleware documentation use the closure notation, while all the $router->get() calls in the Router documentation use controller action strings. 

Lets bridge that gap. I even asked on https://gitter.im/laravel/laravel and nobody knew about [.. ,'uses' => 'Controller@action']