### PR TITLE
[5.8] Make Routes Filename Consistent in Controllers

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -8,7 +8,7 @@
 <a name="introduction"></a>
 ## Introduction
 
-Instead of defining all of your request handling logic in a single `routes.php` file, you may wish to organize this behavior using Controller classes. Controllers can group related HTTP request handling logic into a class. Controllers are stored in the `app/Http/Controllers` directory.
+Instead of defining all of your request handling logic in a single `routes/web.php` file, you may wish to organize this behavior using Controller classes. Controllers can group related HTTP request handling logic into a class. Controllers are stored in the `app/Http/Controllers` directory.
 
 <a name="basic-controllers"></a>
 ## Basic Controllers


### PR DESCRIPTION
This updates the Controller documentation to use the same filename for the routes file as in the Routing documentation.  This was updated for the Routing page in https://github.com/laravel/lumen-docs/pull/114.