### PR TITLE
[6.x] Typo fix

### DIFF
--- a/database.md
+++ b/database.md
@@ -7,7 +7,7 @@
 <a name="configuration"></a>
 ## Configuration
 
-Lumen makes connecting with databases and running queries extremely simple. Currently Lumen supports four database systems: MySQL, Postgres, SQLite, and SQL Server.
+Lumen makes connecting with databases and running queries extremely simple. Currently Lumen supports four database systems: MySQL, PostgreSQL, SQLite, and SQL Server.
 
 You may use the `DB_*` configuration options in your `.env` configuration file to configure your database settings, such as the driver, host, username, and password.
 

--- a/encryption.md
+++ b/encryption.md
@@ -6,7 +6,7 @@
 <a name="configuration"></a>
 ## Configuration
 
-Before using Lumens's encrypter, you should set the `APP_KEY` option of your `.env` file to a 32 character, random string. If this value is not properly set, all values encrypted by Lumen will be insecure.
+Before using Lumen's encrypter, you should set the `APP_KEY` option of your `.env` file to a 32 character, random string. If this value is not properly set, all values encrypted by Lumen will be insecure.
 
 <a name="basic-usage"></a>
 ## Basic Usage

--- a/releases.md
+++ b/releases.md
@@ -58,7 +58,7 @@ Lumen 5.2 represents a shift on slimming Lumen to focus solely on serving statel
 
 ### Authentication
 
-Because sessions are no longer included with Lumen, authentication must be done statelessly using API tokens or headers. You have complete control over the authentication process in the new `AuthServiceProvider`. Please review the [authentication documentation](/docs/{{version}}/authentication) for more information.
+Because sessions are no longer included with Lumen, authentication must be done stateless using API tokens or headers. You have complete control over the authentication process in the new `AuthServiceProvider`. Please review the [authentication documentation](/docs/{{version}}/authentication) for more information.
 
 ### Testing Helpers
 


### PR DESCRIPTION
Typo fix: Lumens's -> Lumen's | Postgres -> PostgreSQL | statelessly-> stateless