### PR TITLE
[7.x] Add timezone setting to Lumen 7 upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -19,6 +19,13 @@ Once you have made the necessary adjustments to your application, you may upgrad
 
     "laravel/lumen-framework": "^7.0"
 
+### Timezone Setting
+
+The timezone setting has been moved from the `lumen-framework` package to the `bootstrap/app.php` file.  
+If you're currently using the `APP_TIMEZONE` environment variable you should add the following to your `bootstrap/app.php` file:
+
+    date_default_timezone_set(env('APP_TIMEZONE', 'UTC'));
+
 ### Symfony 5 Related Upgrades
 
 Lumen 7 utilizes the 5.x series of the Symfony components. Some minor changes to your application are required to accommodate this upgrade.


### PR DESCRIPTION
[#1014](https://github.com/laravel/lumen-framework/pull/1014) removed the timezone setting from the `lumen-framework` package. 
The setting has been moved to the `bootstrap/app.php` file ([#141](https://github.com/laravel/lumen/pull/141/files)) instead.

This is a breaking change and should be mentioned in the upgrade guide.