### PR TITLE
advise to remove local dotenv dep from 5.8 upgrade

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -113,9 +113,7 @@ Lumen 5.8 makes use of the newest implementation of the `vlucas/phpdotenv` libra
 		dirname(__DIR__)
 	))->bootstrap();
 
-Additionally, you'll need to update your dependency in your `composer.json` to the new version:
-
-	"vlucas/phpdotenv": "^3.3"
+Additionally, remove the `vlucas/phpdotenv` in your `composer.json` as it is now a dependency of Lumen.
 
 <a name="upgrade-5.7.0"></a>
 ## Upgrading To 5.7.0 From 5.6

--- a/upgrade.md
+++ b/upgrade.md
@@ -113,7 +113,7 @@ Lumen 5.8 makes use of the newest implementation of the `vlucas/phpdotenv` libra
 		dirname(__DIR__)
 	))->bootstrap();
 
-Additionally, remove the `vlucas/phpdotenv` in your `composer.json` as it is now a dependency of Lumen.
+Additionally, remove the `vlucas/phpdotenv` dependency from your application's `composer.json` file as it is now a dependency of Lumen.
 
 <a name="upgrade-5.7.0"></a>
 ## Upgrading To 5.7.0 From 5.6


### PR DESCRIPTION
I am currently upgrading some old Lumen projects and came across this issue:

In 5.8 [dotenv became a first party dependency of Lumen](https://github.com/laravel/lumen-framework/commit/6cd1ffe80b1123878b82ccea477d1f4f64586ed9), which makes the local dep obsolete.

Additionally, [7.0 requires dotenv 4.0](https://github.com/laravel/lumen-framework/commit/76a38164caf38eb0ab468d17c1f4812412d37e6a), which isn't specified in the upgrade documentation and would require another superfluous local version bump for dotenv.

This is a minor issue but it'll save people from having to run composer twice while upgrading to 7.

Cheers